### PR TITLE
feat: ignore db and provide default separately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ cypress
 # exclude coverage
 /coverage
 .nyc_output
+
+# exclude local database
+db.json

--- a/data/default.json
+++ b/data/default.json
@@ -1,0 +1,3 @@
+{
+  "appInstanceResources": []
+}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "start:api": "json-server --watch data/db.json --port 3636 --id _id --routes data/routes.json",
+    "start:api": "yarn reset:api && json-server --watch data/db.json --port 3636 --id _id --routes data/routes.json",
+    "reset:api": "cat data/default.json > data/db.json",
     "build": "yarn build:react && yarn build:bundle",
     "build:react": "react-scripts build",
     "build:bundle": "webpack --config webpack.config.js --mode=production",


### PR DESCRIPTION
To avoid commiting the db.json file, we now have a default and reset
it every time the api starts.

closes #8